### PR TITLE
feat(tasks): GET /tasks/{id} - get task by id

### DIFF
--- a/TasksAPI.Tests/Services/TaskItemServiceTests.cs
+++ b/TasksAPI.Tests/Services/TaskItemServiceTests.cs
@@ -70,6 +70,20 @@ public class TaskItemServiceTests
     }
 
     [Test]
+    public async Task GetByIdAsync_should_return_task_with_all_fields()
+    {
+        var task = new TaskItem("Tache detail", "in-progress") { Id = 42 };
+        _repositoryMock.Setup(r => r.GetByIdAsync(42)).ReturnsAsync(task);
+
+        var result = await _service.GetByIdAsync(42);
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(42);
+        result.Titre.Should().Be("Tache detail");
+        result.Statut.Should().Be("in-progress");
+    }
+
+    [Test]
     public async Task CreateAsync_should_return_created_task_when_valid_request()
     {
         var request = new CreateTaskItemRequest { Titre = "Nouvelle tache", Statut = "todo" };


### PR DESCRIPTION
## Summary
- `GET /tasks/{id}` retourne 200 avec la tâche (id, titre, statut)
- Retourne 404 si tâche introuvable
- Tests : tâche trouvée avec tous les champs, 404 avec message

Closes #3