### PR TITLE
feat(tasks): PUT /tasks/{id} - partial update

### DIFF
--- a/TasksAPI.Application/DTOs/TaskItemDto.cs
+++ b/TasksAPI.Application/DTOs/TaskItemDto.cs
@@ -15,6 +15,6 @@ public class CreateTaskItemRequest
 
 public class UpdateTaskItemRequest
 {
-    public string Titre { get; init; } = string.Empty;
-    public string Statut { get; init; } = string.Empty;
+    public string? Titre { get; init; }
+    public string? Statut { get; init; }
 }

--- a/TasksAPI.Application/Services/TaskItemService.cs
+++ b/TasksAPI.Application/Services/TaskItemService.cs
@@ -58,7 +58,10 @@ public class TaskItemService : ITaskItemService
         if (existing is null)
             throw new NotFoundException(nameof(TaskItem), id);
 
-        var updated = existing.WithStatut(request.Statut).WithTitre(request.Titre);
+        var updated = existing;
+        if (request.Titre is not null) updated = updated.WithTitre(request.Titre);
+        if (request.Statut is not null) updated = updated.WithStatut(request.Statut);
+
         var saved = await _repository.UpdateAsync(updated);
         return _mapper.Map<TaskItemResponse>(saved);
     }

--- a/TasksAPI.Application/Validators/UpdateTaskItemRequestValidator.cs
+++ b/TasksAPI.Application/Validators/UpdateTaskItemRequestValidator.cs
@@ -9,13 +9,22 @@ public class UpdateTaskItemRequestValidator : AbstractValidator<UpdateTaskItemRe
 
     public UpdateTaskItemRequestValidator()
     {
-        RuleFor(x => x.Titre)
-            .NotEmpty().WithMessage("Le titre est obligatoire.")
-            .MaximumLength(200).WithMessage("Le titre ne peut pas dépasser 200 caractères.");
+        RuleFor(x => x)
+            .Must(x => x.Titre is not null || x.Statut is not null)
+            .WithMessage("Au moins un champ (titre ou statut) doit être fourni.");
 
-        RuleFor(x => x.Statut)
-            .NotEmpty().WithMessage("Le statut est obligatoire.")
-            .Must(s => ValidStatuts.Contains(s))
-            .WithMessage($"Le statut doit être l'une des valeurs suivantes : {string.Join(", ", ValidStatuts)}.");
+        When(x => x.Titre is not null, () =>
+        {
+            RuleFor(x => x.Titre)
+                .NotEmpty().WithMessage("Le titre ne peut pas être vide.")
+                .MaximumLength(100).WithMessage("Le titre ne peut pas dépasser 100 caractères.");
+        });
+
+        When(x => x.Statut is not null, () =>
+        {
+            RuleFor(x => x.Statut)
+                .Must(s => ValidStatuts.Contains(s))
+                .WithMessage($"Le statut doit être l'une des valeurs suivantes : {string.Join(", ", ValidStatuts)}.");
+        });
     }
 }

--- a/TasksAPI.Tests/Services/TaskItemServiceTests.cs
+++ b/TasksAPI.Tests/Services/TaskItemServiceTests.cs
@@ -160,6 +160,38 @@ public class TaskItemServiceTests
         result.Statut.Should().Be("in-progress");
     }
 
+    // Issue #5 - PUT /tasks/{id} : mise a jour partielle du titre uniquement
+    [Test]
+    public async Task UpdateAsync_should_update_only_titre_when_statut_not_provided()
+    {
+        var existing = new TaskItem("Ancien titre", "todo") { Id = 1 };
+        var saved = new TaskItem("Nouveau titre", "todo") { Id = 1 };
+        _repositoryMock.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(existing);
+        _repositoryMock.Setup(r => r.UpdateAsync(It.IsAny<TaskItem>())).ReturnsAsync(saved);
+
+        var request = new UpdateTaskItemRequest { Titre = "Nouveau titre" };
+        var result = await _service.UpdateAsync(1, request);
+
+        result.Titre.Should().Be("Nouveau titre");
+        result.Statut.Should().Be("todo");
+    }
+
+    // Issue #5 - PUT /tasks/{id} : mise a jour partielle du statut uniquement
+    [Test]
+    public async Task UpdateAsync_should_update_only_statut_when_titre_not_provided()
+    {
+        var existing = new TaskItem("Mon titre", "todo") { Id = 2 };
+        var saved = new TaskItem("Mon titre", "done") { Id = 2 };
+        _repositoryMock.Setup(r => r.GetByIdAsync(2)).ReturnsAsync(existing);
+        _repositoryMock.Setup(r => r.UpdateAsync(It.IsAny<TaskItem>())).ReturnsAsync(saved);
+
+        var request = new UpdateTaskItemRequest { Statut = "done" };
+        var result = await _service.UpdateAsync(2, request);
+
+        result.Titre.Should().Be("Mon titre");
+        result.Statut.Should().Be("done");
+    }
+
     // Issue #2 - GET /tasks : chaque tache doit contenir id, titre, statut
     [Test]
     public async Task GetAllAsync_should_return_tasks_with_id_titre_statut_fields()


### PR DESCRIPTION
## Summary
- `PUT /tasks/{id}` supporte la mise à jour partielle (`titre?` et/ou `statut?`)
- Retourne 200 avec la tâche modifiée
- Retourne 404 si tâche introuvable
- Retourne 400 si aucun champ fourni ou valeurs invalides
- `UpdateTaskItemRequest` migré vers champs nullable
- Validator : au moins un champ requis, MaxLength(100) sur titre
- Tests : mise à jour titre seul, statut seul, 404

Closes #5