### PR TITLE
feat(tasks): DELETE /tasks/{id} - returns 204 No Content

### DIFF
--- a/TasksAPI.API/Controllers/TaskItemsController.cs
+++ b/TasksAPI.API/Controllers/TaskItemsController.cs
@@ -60,12 +60,12 @@ public class TaskItemsController : ControllerBase
     }
 
     [HttpDelete("{id:int}")]
-    [ProducesResponseType(typeof(ApiResponse<object>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ApiResponse<object>), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Delete(int id)
     {
         _logger.LogInformation("Deleting task id: {Id}", id);
         await _service.DeleteAsync(id);
-        return Ok(ApiResponse<object>.Ok(new { }, "Tache supprimee avec succes."));
+        return NoContent();
     }
 }

--- a/TasksAPI.Tests/Services/TaskItemServiceTests.cs
+++ b/TasksAPI.Tests/Services/TaskItemServiceTests.cs
@@ -192,6 +192,20 @@ public class TaskItemServiceTests
         result.Statut.Should().Be("done");
     }
 
+    // Issue #6 - DELETE /tasks/{id} : suppression reussie (204 No Content)
+    [Test]
+    public async Task DeleteAsync_should_succeed_when_task_exists()
+    {
+        var existing = new TaskItem("A supprimer", "todo") { Id = 3 };
+        _repositoryMock.Setup(r => r.GetByIdAsync(3)).ReturnsAsync(existing);
+        _repositoryMock.Setup(r => r.DeleteAsync(3)).Returns(Task.CompletedTask);
+
+        Func<Task> act = async () => await _service.DeleteAsync(3);
+
+        await act.Should().NotThrowAsync();
+        _repositoryMock.Verify(r => r.DeleteAsync(3), Times.Once);
+    }
+
     // Issue #2 - GET /tasks : chaque tache doit contenir id, titre, statut
     [Test]
     public async Task GetAllAsync_should_return_tasks_with_id_titre_statut_fields()


### PR DESCRIPTION
## Summary
- `DELETE /tasks/{id}` retourne 204 No Content (corrigé depuis 200 OK)
- Retourne 404 si tâche introuvable (via middleware NotFoundException)
- Test : suppression réussie, vérification appel repository

Closes #6