### PR TITLE
feat(validation): titre obligatoire max 100 caractères

### DIFF
--- a/TasksAPI.Application/DTOs/TaskItemDto.cs
+++ b/TasksAPI.Application/DTOs/TaskItemDto.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace TasksAPI.Application.DTOs;
 
 public class TaskItemResponse
@@ -9,6 +11,8 @@ public class TaskItemResponse
 
 public class CreateTaskItemRequest
 {
+    [Required(ErrorMessage = "Le titre est obligatoire.")]
+    [MaxLength(100, ErrorMessage = "Le titre ne peut pas dépasser 100 caractères.")]
     public string Titre { get; init; } = string.Empty;
     public string Statut { get; init; } = "todo";
 }

--- a/TasksAPI.Application/Validators/CreateTaskItemRequestValidator.cs
+++ b/TasksAPI.Application/Validators/CreateTaskItemRequestValidator.cs
@@ -11,7 +11,7 @@ public class CreateTaskItemRequestValidator : AbstractValidator<CreateTaskItemRe
     {
         RuleFor(x => x.Titre)
             .NotEmpty().WithMessage("Le titre est obligatoire.")
-            .MaximumLength(200).WithMessage("Le titre ne peut pas dépasser 200 caractères.");
+            .MaximumLength(100).WithMessage("Le titre ne peut pas dépasser 100 caractères.");
 
         RuleFor(x => x.Statut)
             .Must(s => ValidStatuts.Contains(s))

--- a/TasksAPI.Tests/Validators/CreateTaskItemRequestValidatorTests.cs
+++ b/TasksAPI.Tests/Validators/CreateTaskItemRequestValidatorTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using NUnit.Framework;
+using TasksAPI.Application.DTOs;
+using TasksAPI.Application.Validators;
+
+namespace TasksAPI.Tests.Validators;
+
+[TestFixture]
+public class CreateTaskItemRequestValidatorTests
+{
+    private CreateTaskItemRequestValidator _validator = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _validator = new CreateTaskItemRequestValidator();
+    }
+
+    // Issue #7 - Retourne 400 si titre est absent ou vide
+    [Test]
+    public void Should_have_error_when_titre_is_empty()
+    {
+        var request = new CreateTaskItemRequest { Titre = string.Empty, Statut = "todo" };
+        var result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.Titre)
+            .WithErrorMessage("Le titre est obligatoire.");
+    }
+
+    // Issue #7 - Retourne 400 si titre depasse 100 caracteres
+    [Test]
+    public void Should_have_error_when_titre_exceeds_100_characters()
+    {
+        var request = new CreateTaskItemRequest { Titre = new string('a', 101), Statut = "todo" };
+        var result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.Titre)
+            .WithErrorMessage("Le titre ne peut pas dépasser 100 caractères.");
+    }
+
+    // Issue #7 - Titre valide de 100 caracteres passe la validation
+    [Test]
+    public void Should_not_have_error_when_titre_is_exactly_100_characters()
+    {
+        var request = new CreateTaskItemRequest { Titre = new string('a', 100), Statut = "todo" };
+        var result = _validator.TestValidate(request);
+        result.ShouldNotHaveValidationErrorFor(x => x.Titre);
+    }
+
+    // Issue #7 - Titre obligatoire : message d erreur clair
+    [Test]
+    public void Should_have_clear_error_message_when_titre_is_null()
+    {
+        var request = new CreateTaskItemRequest { Titre = null!, Statut = "todo" };
+        var result = _validator.TestValidate(request);
+        result.Errors.Should().Contain(e => e.PropertyName == "Titre");
+        result.Errors.Should().Contain(e => e.ErrorMessage.Contains("obligatoire"));
+    }
+}


### PR DESCRIPTION
## Summary
- Validator `CreateTaskItemRequest` : `MaxLength` corrigé de 200 → 100
- Annotations `[Required]` et `[MaxLength(100)]` ajoutées sur le DTO
- Retourne 400 avec message explicite si titre absent, vide ou > 100 chars
- 4 tests dédiés : vide, null, > 100 chars, exactement 100 chars

Closes #7